### PR TITLE
link build badge to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 beautiful logging, TypeScript ready
 
 ## Status
-[![Build Status](https://travis-ci.org/pushrocks/beautylog.svg?branch=v0.0.9)](https://travis-ci.org/pushrocks/beautylog)
+[![Build Status](https://travis-ci.org/pushrocks/beautylog.svg?branch=master)](https://travis-ci.org/pushrocks/beautylog)
 [![Build status](https://ci.appveyor.com/api/projects/status/tglk8r5cwou65ljh/branch/master?svg=true)](https://ci.appveyor.com/project/philkunz/beautylog/branch/master)
 [![Dependency Status](https://david-dm.org/pushrocks/beautylog.svg)](https://david-dm.org/pushrocks/beautylog)
 [![bitHound Dependencies](https://www.bithound.io/github/pushrocks/beautylog/badges/dependencies.svg)](https://www.bithound.io/github/pushrocks/beautylog/master/dependencies/npm)


### PR DESCRIPTION
...didn't knew you could target a release instead of a branch. Anyway, it shouldn't be like that in readme, right?